### PR TITLE
42 fix bugs

### DIFF
--- a/installers/python3.sh
+++ b/installers/python3.sh
@@ -55,7 +55,7 @@ function install_latest_python3 {
     sudo apt-get install -y python${DOT_PYTHON3_VER:-3.8} python3-pip >/dev/null
     # disable global pip
     print_info "Ready to disable pip globally for both python 2 and 3"
-    if [ "$PIP_REQUIRE_VIRTUALENV" == true ]; then
+    if $PIP_REQUIRE_VIRTUALENV; then
         print_success "Pip was already disabled globally"
     else
         print_question "Pip was not yet disabled by dotfiles?"

--- a/setup_symlinks.sh
+++ b/setup_symlinks.sh
@@ -39,7 +39,7 @@ _SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 source $_SCRIPT_PATH/util_funcs.sh
 
 # find all dotfiles to symlink and source and store them in an array
-declare -a FILES_TO_SYMLINK=$(find $_SCRIPT_PATH/basics/ -type f)
+declare -a FILES_TO_SYMLINK=$(find $_SCRIPT_PATH/basics/ -maxdepth 1 -type f)
 
 # find all dotfiles that only need to symlink to user's home folder
 declare -a FILES_ONLY_SYMLINK=$(find $_SCRIPT_PATH/basics/only_symlink/ -type f)


### PR DESCRIPTION
Fixed three bugs:
1. the dotfiles that only need to be soft linked are now no longer wrongly sourced into the `.bashrc`.
2. `PIP_REQUIRE_VIRTUALENV` is now correctly detected as already set during installer execution.
3. added test to check if the docker group already exists and if the user has already been added into docker group.